### PR TITLE
Fix potential nans in th_deis.DisVPSDE

### DIFF
--- a/th_deis/sde.py
+++ b/th_deis/sde.py
@@ -113,6 +113,15 @@ class DisVPSDE:
 
         if last_step:
             steps_out = np.array([0, *steps_out])
+        
+        _, idx = np.unique(steps_out, return_index=True)
+        steps_out = steps_out[np.sort(idx)]
+        
+        remain_steps = num_timesteps + 1 - steps_out.shape[0]
+        if remain_steps > 0:
+            l = np.array([i for i in range(self.t_end) if i not in steps_out][:remain_steps])
+            steps_out = np.concatenate([steps_out, l], axis=0)
+            steps_out = np.sort(steps_out)
 
         return np.flip(steps_out).copy()
 


### PR DESCRIPTION
The coefficients will become NaN if 100 steps, quad, last=False (this is not an issue for uniform). This is because of multiple zeros will appear in the timestep schedules if num_timesteps is large. I fixed it by removing identical steps and adding additional small steps that are unique. This code should run successfully:

```python
import numpy as np
from th_deis import DisVPSDE
beta = np.linspace(0.0001, 0.02, 1000)
alpha = 1 - np.cumprod(1 - beta)
sde = DisVPSDE(alpha)
rev_timesteps = sde.get_rev_timesteps(100, 'quad', False)
assert rev_timesteps.shape[0] == 101
np_ei_ab_coef = sde.get_deis_coef(3, rev_timesteps, 3)
assert np.any(np.isnan(np_ei_ab_coef)) == False
```
